### PR TITLE
fix nil pointer dereference panic and add unit test that was failing

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -26,6 +26,7 @@ func merge(cur, patch *lazyNode) *lazyNode {
 }
 
 func mergeDocs(doc, patch *partialDoc) {
+	pruneDocNulls(doc)
 	for k, v := range *patch {
 		if v == nil {
 			delete(*doc, k)

--- a/merge_test.go
+++ b/merge_test.go
@@ -39,6 +39,19 @@ func TestMergePatchIgnoresOtherValues(t *testing.T) {
 	}
 }
 
+func TestMergePatchNilDoc(t *testing.T) {
+	doc := `{ "title": null }`
+	pat := `{ "title": {"foo": "bar"} }`
+
+	res := mergePatch(doc, pat)
+
+	exp := `{ "title": {"foo": "bar"} }`
+
+	if !compareJSON(exp, res) {
+		t.Fatalf("Key was not replaced")
+	}
+}
+
 func TestMergePatchRecursesIntoObjects(t *testing.T) {
 	doc := `{ "person": { "title": "hello", "age": 18 } }`
 	pat := `{ "person": { "title": "goodbye" } }`


### PR DESCRIPTION
Before prune, test fails with:
```
--- FAIL: TestMergePatchNilDoc (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x28 pc=0x45cf31]

goroutine 7 [running]:
testing.func·006()
	/home/mike/.gvm/gos/go1.4/src/testing/testing.go:441 +0x181
_/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch.(*lazyNode).intoDoc(0x0, 0x6575a0, 0x0, 0x0)
	/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch/patch.go:64 +0x31
_/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch.merge(0x0, 0xc20803a7e0, 0xc20800a7d0)
	/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch/merge.go:10 +0x28
_/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch.mergeDocs(0xc2080340e8, 0xc2080340f8)
	/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch/merge.go:40 +0x1cd
_/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch.MergePatch(0xc20801e980, 0x11, 0x20, 0xc20801e9a0, 0x1b, 0x20, 0x0, 0x0, 0x0, 0x0, ...)
	/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch/merge.go:139 +0x3b8
_/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch.mergePatch(0x5a7690, 0x11, 0x5b0e90, 0x1b, 0x0, 0x0)
	/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch/merge_test.go:9 +0xec
_/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch.TestMergePatchNilDoc(0xc208060120)
	/home/mike/go/src/github.com/GoogleCloudPlatform/kubernetes/Godeps/_workspace/src/github.com/evanphx/json-patch/merge_test.go:46 +0x62
testing.tRunner(0xc208060120, 0x6556f0)
	/home/mike/.gvm/gos/go1.4/src/testing/testing.go:447 +0xbf
created by testing.RunTests
	/home/mike/.gvm/gos/go1.4/src/testing/testing.go:555 +0xa8b
```