### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.4
+  - 1.3
+
+install:
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+
+script:
+  - go test -cover ./...
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Provides the abiilty to modify and test a JSON according to a
 
 *Version*: **1.0**
 
+[![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
+
+[![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=RFC7386)](https://travis-ci.org/evanphx/json-patch)
 
 ### API Usage
 


### PR DESCRIPTION
This is totally optional but config will build PRs and fail on test failures. All you'd need to do is activate the repo on https://travis-ci.org/. I'm currently evaluting this project for use in https://github.com/GoogleCloudPlatform/kubernetes so I'll be checking in occasionally. Thanks for the work! JSON Patch is very useful :)

Also throwing in a godoc badge for kicks.