### PR TITLE
avoid nil dereference when testing values that do not exist

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -425,6 +425,14 @@ func (p Patch) test(doc *partialDoc, op operation) error {
 		return err
 	}
 
+	if val == nil {
+		if op.value().raw == nil {
+			return nil
+		} else {
+			return fmt.Errorf("Testing value %s failed", path)
+		}
+	}
+
 	if val.equal(op.value()) {
 		return nil
 	}

--- a/patch_test.go
+++ b/patch_test.go
@@ -214,6 +214,18 @@ var TestCases = []TestCase{
 		false,
 		"/foo/1",
 	},
+	{
+		`{ "baz": "qux" }`,
+		`[ { "op": "test", "path": "/foo", "value": 42 } ]`,
+		false,
+		"/foo",
+	},
+	{
+		`{ "baz": "qux" }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		true,
+		"",
+	},
 }
 
 func TestAllTest(t *testing.T) {


### PR DESCRIPTION
I ran into this when a patch document had a `test` op referencing a non-existent field.