### PR TITLE
Add detection of unchanged arrays within objects.

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -218,6 +218,9 @@ func matchesValue(av, bv interface{}) bool {
 			}
 		}
 		return true
+	case []interface{}:
+		bt := bv.([]interface{})
+		return matchesArray(at, bt)
 	}
 	return false
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -321,7 +321,7 @@ func TestMergeComplexRemoveAll(t *testing.T) {
 	*/
 }
 
-func TestMergeLargeIdentitalObject(t *testing.T) {
+func TestMergeObjectWithInnerArray(t *testing.T) {
 	stateString := `{
 	  "OuterArray": [
 	    {

--- a/merge_test.go
+++ b/merge_test.go
@@ -320,3 +320,27 @@ func TestMergeComplexRemoveAll(t *testing.T) {
 		}
 	*/
 }
+
+func TestMergeLargeIdentitalObject(t *testing.T) {
+	stateString := `{
+	  "OuterArray": [
+	    {
+		  "InnerArray": [
+	        {
+	          "StringAttr": "abc123"
+	        }
+	      ],
+	      "StringAttr": "def456"
+	    }
+	  ]
+	}`
+
+	patch, err := CreateMergePatch([]byte(stateString), []byte(stateString))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(patch) != "{}" {
+		t.Fatalf("Patch should have been {} but was: %v", string(patch))
+	}
+}


### PR DESCRIPTION
Previously, any pair of objects used to create a merge patch which had an inner array would result in a non-empty patch even if the two objects were completely identical.