### PR TITLE
Support applying patches that contain null values

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -42,7 +42,7 @@ func newLazyNode(raw *json.RawMessage) *lazyNode {
 func (n *lazyNode) MarshalJSON() ([]byte, error) {
 	switch n.which {
 	case eRaw:
-		return *n.raw, nil
+		return json.Marshal(n.raw)
 	case eDoc:
 		return json.Marshal(n.doc)
 	case eAry:

--- a/patch_test.go
+++ b/patch_test.go
@@ -132,6 +132,10 @@ var MutationTestCases = []BadCase{
 		`{ "foo": "bar", "qux": { "baz": 1, "bar": null } }`,
 		`[ { "op": "remove", "path": "/qux/bar" } ]`,
 	},
+	{
+		`{ "foo": "bar", "qux": { "baz": 1, "bar": null } }`,
+		`[ { "op": "replace", "path": "/qux/baz", "value": null } ]`,
+	},
 }
 
 var BadCases = []BadCase{

--- a/patch_test.go
+++ b/patch_test.go
@@ -121,6 +121,11 @@ var Cases = []Case{
 		`[ { "op": "remove", "path": "/qux/bar" } ]`,
 		`{ "foo": "bar", "qux": { "baz": 1 } }`,
 	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "add", "path": "/baz", "value": null } ]`,
+		`{ "baz": null, "foo": "bar" }`,
+	},
 }
 
 type BadCase struct {


### PR DESCRIPTION
Currently, any attempt to apply a patch that either adds a null value or replaces an existing value with a null one will cause a panic. This change fixes the panic by adding support for applying patches with null values.