### PR TITLE
Fix merge of existing array to empty array

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -69,7 +69,7 @@ func pruneDocNulls(doc *partialDoc) *partialDoc {
 }
 
 func pruneAryNulls(ary *partialArray) *partialArray {
-	var newAry []*lazyNode
+	newAry := []*lazyNode{}
 
 	for _, v := range *ary {
 		if v != nil {

--- a/merge_test.go
+++ b/merge_test.go
@@ -107,6 +107,23 @@ func TestMergePatchReturnsErrorOnBadJSON(t *testing.T) {
 	}
 }
 
+func TestMergePatchReturnsEmptyArrayOnEmptyArray(t *testing.T) {
+	doc := `{ "array": ["one", "two"] }`
+	pat := `{ "array": [] }`
+
+	exp := `{ "array": [] }`
+
+	res, err := MergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Emtpy array did not return not return as empty array")
+	}
+}
+
 var rfcTests = []struct {
 	target   string
 	patch    string


### PR DESCRIPTION
When merging to empty arrays, not null but empty arrays should be the result. This PR fixes the variable initialization of the result array to initialize no matter if the incoming array has elements or not. Includes a unit test for this case.