### PR TITLE
Link to current version of JSON Merge Patch RFC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## JSON-Patch
 
 Provides the abiilty to modify and test a JSON according to a
-[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7386 JSON Merge Patch](https://tools.ietf.org/html/rfc7386).
+[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7396 JSON Merge Patch](https://tools.ietf.org/html/rfc7396).
 
 *Version*: **1.0**
 


### PR DESCRIPTION
IETF RFC 7386 was superseded by RFC 7396.