### PR TITLE
Respect path encoding in find object

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -270,7 +270,7 @@ func findObject(pd *partialDoc, path string) (container, string) {
 
 	for _, part := range parts {
 
-		next, ok := doc.get(part)
+		next, ok := doc.get(decodePatchKey(part))
 
 		if next == nil || ok != nil {
 			return nil, ""
@@ -291,7 +291,7 @@ func findObject(pd *partialDoc, path string) (container, string) {
 		}
 	}
 
-	return doc, key
+	return doc, decodePatchKey(key)
 }
 
 func (d *partialDoc) set(key string, val *lazyNode) error {

--- a/patch_test.go
+++ b/patch_test.go
@@ -266,6 +266,12 @@ var TestCases = []TestCase{
 		true,
 		"",
 	},
+	{
+		`{ "baz/foo": "qux" }`,
+		`[ { "op": "test", "path": "/baz~1foo", "value": "qux"} ]`,
+		true,
+		"",
+	},
 }
 
 func TestAllTest(t *testing.T) {


### PR DESCRIPTION
Another fix for path encoding - missed in previous PR.

Would appreciate quick turnaround on this as well if possible so can update a
couple of projects (kubernetes & openshift) that use this library.