### PR TITLE
Fixes typo in error message string

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -311,7 +311,7 @@ func (d *partialDoc) get(key string) (*lazyNode, error) {
 func (d *partialDoc) remove(key string) error {
 	_, ok := (*d)[key]
 	if !ok {
-		return fmt.Errorf("Unable to remove nonexistant key: %s", key)
+		return fmt.Errorf("Unable to remove nonexistent key: %s", key)
 	}
 
 	delete(*d, key)


### PR DESCRIPTION
Fixes a 1-character typo in the error message.  ;-)