### PR TITLE
Prevent slice out of bound panic on invalid patch

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -264,6 +264,10 @@ func findObject(pd *container, path string) (container, string) {
 
 	split := strings.Split(path, "/")
 
+	if len(split) < 2 {
+		return nil, ""
+	}
+
 	parts := split[1 : len(split)-1]
 
 	key := split[len(split)-1]

--- a/patch_test.go
+++ b/patch_test.go
@@ -184,6 +184,14 @@ var BadCases = []BadCase{
 		`{ "a": { "b": [1] } }`,
 		`[ { "op": "move", "from": "/a/b/1", "path": "/a/b/2" } ]`,
 	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "add", "pathz": "/baz", "value": "qux" } ]`,
+	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "add", "path": "", "value": "qux" } ]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {


### PR DESCRIPTION
This prevents a `slice bound out of range` panic when parsing an invalid
json patch where the path key is missing or the path value is empty
string or doesn't include `/`.

Fix https://github.com/kubernetes/kubernetes/issues/40218