### PR TITLE
gofmt and golint fixes

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -14,8 +14,6 @@ const (
 	eAry
 )
 
-const LeftBrace byte = 91 // []byte("[")
-
 type lazyNode struct {
 	raw   *json.RawMessage
 	doc   partialDoc
@@ -495,9 +493,8 @@ func (p Patch) test(doc *container, op operation) error {
 	if val == nil {
 		if op.value().raw == nil {
 			return nil
-		} else {
-			return fmt.Errorf("Testing value %s failed", path)
 		}
+		return fmt.Errorf("Testing value %s failed", path)
 	}
 
 	if val.equal(op.value()) {
@@ -543,7 +540,7 @@ func (p Patch) Apply(doc []byte) ([]byte, error) {
 // document indented.
 func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
 	var pd container
-	if (doc[0] == LeftBrace) {
+	if doc[0] == '[' {
 		pd = &partialArray{}
 	} else {
 		pd = &partialDoc{}

--- a/patch_test.go
+++ b/patch_test.go
@@ -19,12 +19,12 @@ func reformatJSON(j string) string {
 func compareJSON(a, b string) bool {
 	// return Equal([]byte(a), []byte(b))
 
-	var obj_a, obj_b map[string]interface{}
-	json.Unmarshal([]byte(a), &obj_a)
-	json.Unmarshal([]byte(b), &obj_b)
+	var objA, objB map[string]interface{}
+	json.Unmarshal([]byte(a), &objA)
+	json.Unmarshal([]byte(b), &objB)
 
-	// fmt.Printf("Comparing %#v\nagainst %#v\n", obj_a, obj_b)
-	return reflect.DeepEqual(obj_a, obj_b)
+	// fmt.Printf("Comparing %#v\nagainst %#v\n", objA, objB)
+	return reflect.DeepEqual(objA, objB)
 }
 
 func applyPatch(doc, patch string) (string, error) {


### PR DESCRIPTION
While fixing #35 I found a couple of gofmt and golint issues that I wanted to cleanup.

Most notably I removed the const `LeftBrace` and just used the the `'['` char literal as that is more clear than a byte variable with the value `91` IMO :)
I assume no one is depending on this const outside of this library.