### PR TITLE
Check target location for 'Replace' before replacing value

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -446,6 +446,11 @@ func (p Patch) replace(doc *container, op operation) error {
 		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
 	}
 
+	val, ok := con.get(key)
+	if val == nil || ok != nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
+	}
+
 	return con.set(key, op.value())
 }
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -207,6 +207,14 @@ var BadCases = []BadCase{
 		`{ "foo": "bar" }`,
 		`[ { "op": "add", "path": "", "value": "qux" } ]`,
 	},
+	{
+		`{ "foo": ["bar","baz"]}`,
+		`[ { "op": "replace", "path": "/foo/2", "value": "bum"}]`,
+	},
+	{
+		`{ "name":{ "foo": "bat", "qux": "bum"}}`,
+		`[ { "op": "replace", "path": "/foo/bar", "value":"baz"}]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {


### PR DESCRIPTION
* Checked if a key exists in doc before replacing
* Added unit tests to BadCase

Resolves: [#40](https://github.com/evanphx/json-patch/issues/40)

Opened the pull request just in case you decide #40 is a bug. Please close it if you think it is not.