### PR TITLE
Add cmd/ for consuming json-patch via CLI

### DIFF
--- a/cmd/json-patch/file_flag.go
+++ b/cmd/json-patch/file_flag.go
@@ -1,0 +1,39 @@
+package main
+
+// Borrowed from Concourse: https://github.com/concourse/atc/blob/master/atccmd/file_flag.go
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileFlag is a flag for passing a path to a file on disk. The file is
+// expected to be a file, not a directory, that actually exists.
+type FileFlag string
+
+// UnmarshalFlag implements go-flag's Unmarshaler interface
+func (f *FileFlag) UnmarshalFlag(value string) error {
+	stat, err := os.Stat(value)
+	if err != nil {
+		return err
+	}
+
+	if stat.IsDir() {
+		return fmt.Errorf("path '%s' is a directory, not a file", value)
+	}
+
+	abs, err := filepath.Abs(value)
+	if err != nil {
+		return err
+	}
+
+	*f = FileFlag(abs)
+
+	return nil
+}
+
+// Path is the path to the file
+func (f FileFlag) Path() string {
+	return string(f)
+}

--- a/cmd/json-patch/main.go
+++ b/cmd/json-patch/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type opts struct {
+	PatchFilePaths []FileFlag `long:"patch-file" short:"p" value-name:"PATH" description:"Path to file with one or more operations"`
+}
+
+func main() {
+	var o opts
+	_, err := flags.Parse(&o)
+	if err != nil {
+		log.Fatalf("error: %s\n", err)
+	}
+
+	patches := make([]jsonpatch.Patch, len(o.PatchFilePaths))
+
+	for i, patchFilePath := range o.PatchFilePaths {
+		var bs []byte
+		bs, err = ioutil.ReadFile(patchFilePath.Path())
+		if err != nil {
+			log.Fatalf("error reading patch file: %s", err)
+		}
+
+		var patch jsonpatch.Patch
+		patch, err = jsonpatch.DecodePatch(bs)
+		if err != nil {
+			log.Fatalf("error decoding patch file: %s", err)
+		}
+
+		patches[i] = patch
+	}
+
+	doc, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("error reading from stdin: %s", err)
+	}
+
+	mdoc := doc
+	for _, patch := range patches {
+		mdoc, err = patch.Apply(mdoc)
+		if err != nil {
+			log.Fatalf("error applying patch: %s", err)
+		}
+	}
+
+	fmt.Printf("%s", mdoc)
+}


### PR DESCRIPTION
I'm open to changing the implementation around a bit. The CLI approach makes it very handy to do e.g.:

```
~> cat doc.json
{
	"foo": "bar"
}
~> cat patch.json
[
	{"op":"add","path":"/baz","value":"quux"}
]
~> cat doc.json | json-patch -o patch.json
{"baz":"quux","foo":"bar"}
```