### PR TITLE
fixed negative array index bug

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -369,6 +369,15 @@ func (d *partialArray) add(key string, val *lazyNode) error {
 
 	cur := *d
 
+	if idx < 0 {
+		idx *= -1
+
+		if idx > len(ary) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+		idx = len(ary) - idx
+	}
+
 	copy(ary[0:idx], cur[0:idx])
 	ary[idx] = val
 	copy(ary[idx+1:], cur[idx:])

--- a/patch_test.go
+++ b/patch_test.go
@@ -66,6 +66,13 @@ var Cases = []Case{
 		`{ "foo": [ "bar", "qux", "baz" ] }`,
 	},
 	{
+		`{ "foo": [ "bar", "baz" ] }`,
+		`[
+     { "op": "add", "path": "/foo/-1", "value": "qux" }
+    ]`,
+		`{ "foo": [ "bar", "baz", "qux" ] }`,
+	},
+	{
 		`{ "baz": "qux", "foo": "bar" }`,
 		`[ { "op": "remove", "path": "/baz" } ]`,
 		`{ "foo": "bar" }`,
@@ -211,6 +218,11 @@ var BadCases = []BadCase{
 		`{ "foo": ["bar","baz"]}`,
 		`[ { "op": "replace", "path": "/foo/2", "value": "bum"}]`,
 	},
+	{
+		`{ "foo": ["bar","baz"]}`,
+		`[ { "op": "add", "path": "/foo/-4", "value": "bum"}]`,
+	},
+
 	{
 		`{ "name":{ "foo": "bat", "qux": "bum"}}`,
 		`[ { "op": "replace", "path": "/foo/bar", "value":"baz"}]`,


### PR DESCRIPTION
This addresses the issue raised in issue https://github.com/evanphx/json-patch/issues/43.
The `tl;dr` of it the PR is to allow utilizing the `add` operation while specifying a valid negative index.

Note: I was not sure whether `func (d *partialArray) add(...) error` ought to panic or return an error. The reason I was unsure is because, _currently_, if you try to use an invalid positive array index it causes a runtime panic. I ended up have it returning an error in case an invalid negative index is used. I can change that if you would prefer.

Thanks! Let me know if you have any feedback.

Signed-off-by: Curtis La Graff <curtis@amberengine.com>