### PR TITLE
fix bug on matchesValue for nil type

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -224,6 +224,9 @@ func matchesValue(av, bv interface{}) bool {
 		if bt == at {
 			return true
 		}
+	case nil:
+		// Both nil, fine.
+		return true
 	case map[string]interface{}:
 		bt := bv.(map[string]interface{})
 		for key := range at {

--- a/merge_test.go
+++ b/merge_test.go
@@ -271,6 +271,23 @@ func TestMergeEmptyArray(t *testing.T) {
 	}
 }
 
+func TestCreateMergePatchNil(t *testing.T) {
+	doc := `{ "title": "hello", "nested": {"one": 1, "two": [{"one":null}, {"two":null}, {"three":null}]} }`
+	pat := doc
+
+	exp := `{}`
+
+	res, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Object array was not added")
+	}
+}
+
 func TestMergeObjArray(t *testing.T) {
 	doc := `{ "array": [ {"a": {"b": 2}}, {"a": {"b": 3}} ]}`
 	exp := `{}`


### PR DESCRIPTION
When the value type is nil, it should be considered as equal.