### PR TITLE
add nil-pointer checks to avoid runtime panics

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -66,6 +66,10 @@ func (n *lazyNode) intoDoc() (*partialDoc, error) {
 		return &n.doc, nil
 	}
 
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial document")
+	}
+
 	err := json.Unmarshal(*n.raw, &n.doc)
 
 	if err != nil {
@@ -81,6 +85,10 @@ func (n *lazyNode) intoAry() (*partialArray, error) {
 		return &n.ary, nil
 	}
 
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial array")
+	}
+
 	err := json.Unmarshal(*n.raw, &n.ary)
 
 	if err != nil {
@@ -94,6 +102,10 @@ func (n *lazyNode) intoAry() (*partialArray, error) {
 func (n *lazyNode) compact() []byte {
 	buf := &bytes.Buffer{}
 
+	if n.raw == nil {
+		return nil
+	}
+
 	err := json.Compact(buf, *n.raw)
 
 	if err != nil {
@@ -104,6 +116,10 @@ func (n *lazyNode) compact() []byte {
 }
 
 func (n *lazyNode) tryDoc() bool {
+	if n.raw == nil {
+		return false
+	}
+
 	err := json.Unmarshal(*n.raw, &n.doc)
 
 	if err != nil {
@@ -115,6 +131,10 @@ func (n *lazyNode) tryDoc() bool {
 }
 
 func (n *lazyNode) tryAry() bool {
+	if n.raw == nil {
+		return false
+	}
+
 	err := json.Unmarshal(*n.raw, &n.ary)
 
 	if err != nil {

--- a/patch_test.go
+++ b/patch_test.go
@@ -315,6 +315,24 @@ var TestCases = []TestCase{
 		"",
 	},
 	{
+		`{ "foo": null }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		true,
+		"",
+	},
+	{
+		`{ "foo": {} }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		false,
+		"/foo",
+	},
+	{
+		`{ "foo": [] }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		false,
+		"/foo",
+	},
+	{
 		`{ "baz/foo": "qux" }`,
 		`[ { "op": "test", "path": "/baz~1foo", "value": "qux"} ]`,
 		true,


### PR DESCRIPTION
Addresses the nil-pointer issue of `tryDoc` and `tryAry`.
Inspired by [schylek's PR #49 ](https://github.com/evanphx/json-patch/pull/49).

Also adds a couple extra nil-pointer checks for `lazyNode`.

However, because how everything is currently coded, I don't see an avenue for `intoDoc()`, `intoAry()`, or `compact()` to actually _have_ nil pointers to the `n.raw` property. So this was mostly "future-proofing" in case this ever changes. I can remove these extra checks or change the error messages if you would like 👍.

Doesn't modify the license.