### PR TITLE
Surround path with quotes for easier interpretation.

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -450,7 +450,7 @@ func (p Patch) add(doc *container, op operation) error {
 	con, key := findObject(doc, path)
 
 	if con == nil {
-		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: %s", path)
+		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: \"%s\"", path)
 	}
 
 	return con.add(key, op.value())
@@ -462,7 +462,7 @@ func (p Patch) remove(doc *container, op operation) error {
 	con, key := findObject(doc, path)
 
 	if con == nil {
-		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: %s", path)
+		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: \"%s\"", path)
 	}
 
 	return con.remove(key)


### PR DESCRIPTION
This is in part due to the issue here:

https://github.com/kubernetes/kubernetes/issues/63247

Where the path ended up being:

`/spec/template/spec/containers/0/image\"`

(notice the stray quote at the end)

And thus the error message:

`doc is missing /spec/template/spec/containers/0/image"` 

was hard to interpret.