### PR TITLE
Allow replacement of null values

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -477,8 +477,8 @@ func (p Patch) replace(doc *container, op operation) error {
 		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
 	}
 
-	val, ok := con.get(key)
-	if val == nil || ok != nil {
+	_, ok := con.get(key)
+	if ok != nil {
 		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
 	}
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -168,6 +168,26 @@ var Cases = []Case{
 		`[ { "op": "copy", "from": "/0/foo/bar", "path": "/0/baz/bar"}]`,
 		`[ { "baz": {"bar": ["qux","baz"], "qux":"bum"}, "foo": {"bar": ["qux","baz"]}}]`,
 	},
+	{
+		`{ "bar": [{"baz": null}]}`,
+		`[ { "op": "replace", "path": "/bar/0/baz", "value": 1 } ]`,
+		`{ "bar": [{"baz": 1}]}`,
+	},
+	{
+		`{ "bar": [{"baz": 1}]}`,
+		`[ { "op": "replace", "path": "/bar/0/baz", "value": null } ]`,
+		`{ "bar": [{"baz": null}]}`,
+	},
+	{
+		`{ "bar": [null]}`,
+		`[ { "op": "replace", "path": "/bar/0", "value": 1 } ]`,
+		`{ "bar": [1]}`,
+	},
+	{
+		`{ "bar": [1]}`,
+		`[ { "op": "replace", "path": "/bar/0", "value": null } ]`,
+		`{ "bar": [null]}`,
+	},
 }
 
 type BadCase struct {


### PR DESCRIPTION
The current code does not allow a null value to be replaced although there doesn't seem to be any test support for this.  So far as I can tell from the spec, a null is a legitimate json value that can be replaced by another value.

I added a few extra tests for other related cases as well just to prevent regressions.