### PR TITLE
fix test panic

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -236,7 +236,7 @@ func (o operation) path() string {
 }
 
 func (o operation) from() string {
-	if obj, ok := o["from"]; ok && obj != nil{
+	if obj, ok := o["from"]; ok && obj != nil {
 		var op string
 
 		err := json.Unmarshal(*obj, &op)
@@ -534,6 +534,8 @@ func (p Patch) test(doc *container, op operation) error {
 		if op.value().raw == nil {
 			return nil
 		}
+		return fmt.Errorf("Testing value %s failed", path)
+	} else if op.value() == nil {
 		return fmt.Errorf("Testing value %s failed", path)
 	}
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -374,6 +374,12 @@ var TestCases = []TestCase{
 		true,
 		"",
 	},
+	{
+		`{ "foo": [] }`,
+		`[ { "op": "test", "path": "/foo"} ]`,
+		false,
+		"/foo",
+	},
 }
 
 func TestAllTest(t *testing.T) {


### PR DESCRIPTION
Without this change, the following code would panic:
```
package main

import (
        "fmt"

        jsonpatch "github.com/evanphx/json-patch"
)

func main() {
        original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
        patchJSON := []byte(`[
                {"op": "test", "path": "/name"}
        ]`)

        patch, err := jsonpatch.DecodePatch(patchJSON)
        if err != nil {
		fmt.Printf("decode %v\n", err)
		return
        }

        modified, err := patch.Apply(original)
        if err != nil {
		fmt.Printf("aplly %v\n", err)
		return
        }

        fmt.Printf("Original document: %s\n", original)
        fmt.Printf("Modified document: %s\n", modified)
}

```