### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go get -u github.com/evanphx/json-patch
 
 # Configuration
 
-There is a single global configuration variable `jsonpatch.SupportNegativeIndices'. This
+There is a single global configuration variable `jsonpatch.SupportNegativeIndices`. This
 defaults to `true` and enables the non-standard practice of allowing negative indices
 to mean indices starting at the end of an array. This functionality can be disabled
 by setting `jsonpatch.SupportNegativeIndices = false`.


### PR DESCRIPTION
I was reading about JSONPATCH and got into this library. Thank you for your library!

The README is looking odd because of a typo in the Markdown.