### PR TITLE
In "copy" operation, deep copy the source container to prevent loops

### DIFF
--- a/patch_test.go
+++ b/patch_test.go
@@ -192,7 +192,11 @@ var Cases = []Case{
           ]
         }`,
 	},
-
+	{
+		`{ "foo": ["bar"]}`,
+		`[{"op": "copy", "path": "/foo/0", "from": "/foo"}]`,
+		`{ "foo": [["bar"]]}`,
+	},
 	{
 		`{ "foo": ["bar","qux","baz"]}`,
 		`[ { "op": "remove", "path": "/foo/-2"}]`,


### PR DESCRIPTION
Otherwise the added test case can cause a stack overflow.

I have considered adding a loop detection before doing the deep copy, but given that the `lazyNode` is lazily initializing, I think blindly deep copying is acceptable.

@evanphx 