### PR TITLE
Copy should add, not replace

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -617,7 +617,7 @@ func (p Patch) copy(doc *container, op operation) error {
 		return err
 	}
 
-	return con.set(key, valCopy)
+	return con.add(key, valCopy)
 }
 
 // Equal indicates if 2 JSON documents have the same structural equality.

--- a/patch_test.go
+++ b/patch_test.go
@@ -175,27 +175,8 @@ var Cases = []Case{
 	},
 	{
 		`{ "foo": ["bar"]}`,
-		`[{"op": "copy", "path": "/foo/10", "from": "/foo/0"}]`,
-		`{
-          "foo": [
-            "bar",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            "bar"
-          ]
-        }`,
-	},
-	{
-		`{ "foo": ["bar"]}`,
 		`[{"op": "copy", "path": "/foo/0", "from": "/foo"}]`,
-		`{ "foo": [["bar"]]}`,
+		`{ "foo": [["bar"], "bar"]}`,
 	},
 	{
 		`{ "foo": ["bar","qux","baz"]}`,
@@ -317,9 +298,10 @@ var BadCases = []BadCase{
 		`{ "foo": ["bar"]}`,
 		`[{"op": "copy", "path": "/foo/6666666666", "from": "/"}]`,
 	},
+	// Can't copy into an index greater than the size of the array
 	{
 		`{ "foo": ["bar"]}`,
-		`[{"op": "copy", "path": "/foo/11", "from": "/"}]`,
+		`[{"op": "copy", "path": "/foo/2", "from": "/foo/0"}]`,
 	},
 }
 
@@ -354,7 +336,7 @@ func TestAllCases(t *testing.T) {
 		_, err := applyPatch(c.doc, c.patch)
 
 		if err == nil {
-			t.Errorf("Patch should have failed to apply but it did not")
+			t.Errorf("Patch %q should have failed to apply but it did not", c.patch)
 		}
 	}
 }


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc6902#section-4.5:
```
"copy" ... is functionally identical to an "add" operation at the target location using the value specified in the "from" member.
```

(The first commit is #71)