### PR TITLE
"move should functionally equal to "remove" followed by "add"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ go get -u github.com/evanphx/json-patch
   limits the length of any array the patched object can have. It defaults to 0,
   which means there is no limit.
 
+<<<<<<< HEAD
 * There is a global configuration variable `jsonpatch.ArraySizeAdditionLimit`,
   which limits the increase of array length caused by each operation. It
   defaults to 0, which means there is no limit.
@@ -46,6 +47,8 @@ go get -u github.com/evanphx/json-patch
   which limits the total size increase in bytes caused by "copy" operations in a
   patch. It defaults to 0, which means there is no limit.
 
+=======
+>>>>>>> Since that the "set" method is now only called to implement the
 ## Create and apply a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a [Merge Patch](https://tools.ietf.org/html/rfc7396) document. 

--- a/README.md
+++ b/README.md
@@ -34,21 +34,10 @@ go get -u github.com/evanphx/json-patch
   functionality can be disabled by setting `jsonpatch.SupportNegativeIndices =
   false`.
 
-* There is a global configuration variable `jsonpatch.ArraySizeLimit`, which
-  limits the length of any array the patched object can have. It defaults to 0,
-  which means there is no limit.
-
-<<<<<<< HEAD
-* There is a global configuration variable `jsonpatch.ArraySizeAdditionLimit`,
-  which limits the increase of array length caused by each operation. It
-  defaults to 0, which means there is no limit.
-
 * There is a global configuration variable `jsonpatch.AccumulatedCopySizeLimit`,
   which limits the total size increase in bytes caused by "copy" operations in a
   patch. It defaults to 0, which means there is no limit.
 
-=======
->>>>>>> Since that the "set" method is now only called to implement the
 ## Create and apply a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a [Merge Patch](https://tools.ietf.org/html/rfc7396) document. 

--- a/patch.go
+++ b/patch.go
@@ -565,7 +565,7 @@ func (p Patch) move(doc *container, op operation) error {
 		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing destination path: %s", path)
 	}
 
-	return con.set(key, val)
+	return con.add(key, val)
 }
 
 func (p Patch) test(doc *container, op operation) error {

--- a/patch.go
+++ b/patch.go
@@ -19,7 +19,6 @@ var (
 	// allowing negative indices to mean indices starting at the end of an array.
 	// Default to true.
 	SupportNegativeIndices bool = true
-	ArraySizeLimit         int  = 0
 	// AccumulatedCopySizeLimit limits the total size increase in bytes caused by
 	// "copy" operations in a patch.
 	AccumulatedCopySizeLimit int64 = 0
@@ -390,9 +389,6 @@ func (d *partialArray) add(key string, val *lazyNode) error {
 	}
 
 	sz := len(*d) + 1
-	if ArraySizeLimit > 0 && sz > ArraySizeLimit {
-		return fmt.Errorf("Unable to create array of size %d, limit is %d", sz, ArraySizeLimit)
-	}
 
 	ary := make([]*lazyNode, sz)
 

--- a/patch.go
+++ b/patch.go
@@ -20,7 +20,6 @@ var (
 	// Default to true.
 	SupportNegativeIndices bool = true
 	ArraySizeLimit         int  = 0
-	ArraySizeAdditionLimit int  = 0
 	// AccumulatedCopySizeLimit limits the total size increase in bytes caused by
 	// "copy" operations in a patch.
 	AccumulatedCopySizeLimit int64 = 0
@@ -368,44 +367,14 @@ func (d *partialDoc) remove(key string) error {
 	return nil
 }
 
+// set should only be used to implement the "replace" operation, so "key" must
+// be an already existing index in "d".
 func (d *partialArray) set(key string, val *lazyNode) error {
-	if key == "-" {
-		*d = append(*d, val)
-		return nil
-	}
-
 	idx, err := strconv.Atoi(key)
 	if err != nil {
 		return err
 	}
-
-	sz := len(*d)
-
-	if diff := idx + 1 - sz; ArraySizeAdditionLimit > 0 && diff > ArraySizeAdditionLimit {
-		return fmt.Errorf("Unable to increase the array size by %d, the limit is %d", diff, ArraySizeAdditionLimit)
-	}
-
-	if idx+1 > sz {
-		sz = idx + 1
-	}
-
-	if ArraySizeLimit > 0 && sz > ArraySizeLimit {
-		return NewArraySizeError(ArraySizeLimit, sz)
-	}
-
-	ary := make([]*lazyNode, sz)
-
-	cur := *d
-
-	copy(ary, cur)
-
-	if idx >= len(ary) {
-		return fmt.Errorf("Unable to access invalid index: %d", idx)
-	}
-
-	ary[idx] = val
-
-	*d = ary
+	(*d)[idx] = val
 	return nil
 }
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -122,6 +122,11 @@ var Cases = []Case{
 		`{ "foo": [ "all", "cows", "eat", "grass" ] }`,
 	},
 	{
+		`{ "foo": [ "all", "grass", "cows", "eat" ] }`,
+		`[ { "op": "move", "from": "/foo/1", "path": "/foo/2" } ]`,
+		`{ "foo": [ "all", "cows", "grass", "eat" ] }`,
+	},
+	{
 		`{ "foo": "bar" }`,
 		`[ { "op": "add", "path": "/child", "value": { "grandchild": { } } } ]`,
 		`{ "foo": "bar", "child": { "grandchild": { } } }`,
@@ -321,6 +326,11 @@ var BadCases = []BadCase{
 		// size, so each copy operation increases the size by 51 bytes.
 		`[ { "op": "copy", "path": "/foo/-", "from": "/foo/1" },
 		   { "op": "copy", "path": "/foo/-", "from": "/foo/1" }]`,
+	},
+	// Can't move into an index greater than or equal to the size of the array
+	{
+		`{ "foo": [ "all", "grass", "cows", "eat" ] }`,
+		`[ { "op": "move", "from": "/foo/1", "path": "/foo/4" } ]`,
 	},
 }
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -335,22 +335,19 @@ var BadCases = []BadCase{
 }
 
 // This is not thread safe, so we cannot run patch tests in parallel.
-func configureGlobals(arraySizeLimit, arraySizeAdditionLimit int, accumulatedCopySizeLimit int64) func() {
+func configureGlobals(arraySizeLimit int, accumulatedCopySizeLimit int64) func() {
 	oldArraySizeLimit := ArraySizeLimit
-	oldArraySizeAdditionLimit := ArraySizeAdditionLimit
 	oldAccumulatedCopySizeLimit := AccumulatedCopySizeLimit
 	ArraySizeLimit = arraySizeLimit
-	ArraySizeAdditionLimit = arraySizeAdditionLimit
 	AccumulatedCopySizeLimit = accumulatedCopySizeLimit
 	return func() {
 		ArraySizeLimit = oldArraySizeLimit
-		ArraySizeAdditionLimit = oldArraySizeAdditionLimit
 		AccumulatedCopySizeLimit = oldAccumulatedCopySizeLimit
 	}
 }
 
 func TestAllCases(t *testing.T) {
-	defer configureGlobals(1000, 10, int64(100))()
+	defer configureGlobals(1000, int64(100))()
 	for _, c := range Cases {
 		out, err := applyPatch(c.doc, c.patch)
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -335,19 +335,16 @@ var BadCases = []BadCase{
 }
 
 // This is not thread safe, so we cannot run patch tests in parallel.
-func configureGlobals(arraySizeLimit int, accumulatedCopySizeLimit int64) func() {
-	oldArraySizeLimit := ArraySizeLimit
+func configureGlobals(accumulatedCopySizeLimit int64) func() {
 	oldAccumulatedCopySizeLimit := AccumulatedCopySizeLimit
-	ArraySizeLimit = arraySizeLimit
 	AccumulatedCopySizeLimit = accumulatedCopySizeLimit
 	return func() {
-		ArraySizeLimit = oldArraySizeLimit
 		AccumulatedCopySizeLimit = oldAccumulatedCopySizeLimit
 	}
 }
 
 func TestAllCases(t *testing.T) {
-	defer configureGlobals(1000, int64(100))()
+	defer configureGlobals(int64(100))()
 	for _, c := range Cases {
 		out, err := applyPatch(c.doc, c.patch)
 


### PR DESCRIPTION
(Please review #74 first, sorry for messing up the order)

According to the RFC, "move" should `functionally identical to a "remove" operation on the "from" location, followed immediately by an "add" operation at the target location with the value that was just removed`. The library was doing a "remove" followed by a "replace" (i.e., set). The first commit fixed that.

The second commit removed the sanity check on the index in `partialArray.set()`, because `set` is now only called from `replace`, where the index must exist.

The second commit also removed the `ArraySizeAdditionLimit`, because the "move" and "copy" operation now can only at most increase array size by 1.

The third commit removed the `ArraySizeLimit`. See the commit message for why it's not useful anymore.

Thank you, @evanphx.