### PR TITLE
Ability to use custom JSON marshal / unmarshal library

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ go get -u github.com/evanphx/json-patch
   which limits the total size increase in bytes caused by "copy" operations in a
   patch. It defaults to 0, which means there is no limit.
 
+* To have jsonpatch use a custom JSON library for `Marshal()`, `Unmarshal()`,
+  and `MarshalIndent()` calls, use `jsonpatch.SetAPI(otherJsonApi)`,
+  which will configure jsonpatch to globally use `otherJsonApi` for these
+  operations. `otherJsonApi` must implement the three methods in the `API` interface.
+  To reset to using the standard JSON library, use `jsonpatch.ResetAPI()`.
+
 ## Create and apply a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a [Merge Patch](https://tools.ietf.org/html/rfc7396) document. 

--- a/api.go
+++ b/api.go
@@ -1,0 +1,20 @@
+package jsonpatch
+
+import (
+	"github.com/evanphx/json-patch/json"
+)
+
+// GetAPI returns the json API instance being used
+func GetAPI() json.API {
+	return json.GetAPI()
+}
+
+// SetAPI changes the json API instance being used
+func SetAPI(newApi json.API) {
+	json.SetAPI(newApi)
+}
+
+// ResetAPI sets back to using standard json API
+func ResetAPI() {
+	json.ResetAPI()
+}

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,76 @@
+package jsonpatch
+
+import (
+	stdlib "encoding/json"
+	"strings"
+	"testing"
+)
+
+type customJsonApi struct {
+}
+
+func (api customJsonApi) Marshal(v interface{}) ([]byte, error) {
+	output, err := stdlib.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	stringOutput := string(output)
+	if stringOutput != "" && strings.Contains(stringOutput, "bar") {
+		newString := strings.Replace(stringOutput, "bar", "BAR", -1)
+		return []byte(newString), nil
+	}
+	return output, nil
+}
+
+func (api customJsonApi) Unmarshal(data []byte, v interface{}) error {
+	return stdlib.Unmarshal(data, v)
+}
+
+func (api customJsonApi) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return stdlib.MarshalIndent(v, prefix, indent)
+}
+
+func TestMergePatchWithCustomMarshal(t *testing.T) {
+
+	SetAPI(customJsonApi{})
+
+	doc := `{ "hello": "goodbye", "foo": "bar" }`
+	patch := `{ "bed": "time", "good": "night" }`
+	expectedOutput := `{"bed":"time","foo":"BAR","good":"night","hello":"goodbye"}`
+
+	out, err := MergePatch([]byte(doc), []byte(patch))
+
+	if err != nil {
+		t.Fatalf("Error performing merge patch")
+	} else {
+		result := string(out)
+		if result != expectedOutput {
+			t.Errorf(
+				`expected "%s" but received "%s"`,
+				expectedOutput,
+				result,
+			)
+		}
+	}
+
+	// Verify that we can reset to using the standard API
+	ResetAPI()
+
+	expectedOutput = `{"bed":"time","foo":"bar","good":"night","hello":"goodbye"}`
+
+	out, err = MergePatch([]byte(doc), []byte(patch))
+
+	if err != nil {
+		t.Fatalf("Error performing merge patch")
+	} else {
+		result := string(out)
+		if result != expectedOutput {
+			t.Errorf(
+				`expected "%s" but received "%s"`,
+				expectedOutput,
+				result,
+			)
+		}
+	}
+
+}

--- a/json/json.go
+++ b/json/json.go
@@ -1,0 +1,67 @@
+package json
+
+import (
+	"bytes"
+	stdlib "encoding/json"
+)
+
+var useApi API
+
+type API interface {
+	Marshal(v interface{}) ([]byte, error)
+	MarshalIndent(v interface{}, prefix, indent string) ([]byte, error)
+	Unmarshal(data []byte, v interface{}) error
+}
+
+// The standard JSON API does not return a struct,
+// so we provide a pass-through implementation
+// that implements the standard API's methods.
+type stdApi struct {
+}
+
+func (api stdApi) Marshal(v interface{}) ([]byte, error) {
+	return stdlib.Marshal(v)
+}
+func (api stdApi) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return stdlib.MarshalIndent(v, prefix, indent)
+}
+func (api stdApi) Unmarshal(data []byte, v interface{}) error {
+	return stdlib.Unmarshal(data, v)
+}
+
+// Methods which we will defer to standard library for
+func Compact(dst *bytes.Buffer, src []byte) error {
+	return stdlib.Compact(dst, src)
+}
+func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
+	return stdlib.Indent(dst, src, prefix, indent)
+}
+
+// Methods which custom interface MUST implement
+func Marshal(v interface{}) ([]byte, error) {
+	return GetAPI().Marshal(v)
+}
+func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return GetAPI().MarshalIndent(v, prefix, indent)
+}
+func Unmarshal(data []byte, v interface{}) error {
+	return GetAPI().Unmarshal(data, v)
+}
+
+// GetAPI returns the json API instance being used
+func GetAPI() API {
+	if useApi == nil {
+		useApi = stdApi{}
+	}
+	return useApi
+}
+
+// SetAPI changes the json API instance being used
+func SetAPI(newApi API) {
+	useApi = newApi
+}
+
+// ResetAPI sets back to using standard json API
+func ResetAPI() {
+	useApi = stdApi{}
+}

--- a/merge.go
+++ b/merge.go
@@ -2,9 +2,11 @@ package jsonpatch
 
 import (
 	"bytes"
-	"encoding/json"
+	stdlib "encoding/json"
 	"fmt"
 	"reflect"
+
+	json "github.com/evanphx/json-patch/json"
 )
 
 func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
@@ -113,11 +115,11 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 
 	patchErr := json.Unmarshal(patchData, patch)
 
-	if _, ok := docErr.(*json.SyntaxError); ok {
+	if _, ok := docErr.(*stdlib.SyntaxError); ok {
 		return nil, errBadJSONDoc
 	}
 
-	if _, ok := patchErr.(*json.SyntaxError); ok {
+	if _, ok := patchErr.(*stdlib.SyntaxError); ok {
 		return nil, errBadJSONPatch
 	}
 
@@ -228,8 +230,8 @@ func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 // pair of JSON documents provided in the arrays.
 // Arrays of mismatched sizes will result in an error.
 func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
-	originalDocs := []json.RawMessage{}
-	modifiedDocs := []json.RawMessage{}
+	originalDocs := []stdlib.RawMessage{}
+	modifiedDocs := []stdlib.RawMessage{}
 
 	err := json.Unmarshal(originalJSON, &originalDocs)
 	if err != nil {
@@ -246,7 +248,7 @@ func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 		return nil, errBadJSONDoc
 	}
 
-	result := []json.RawMessage{}
+	result := []stdlib.RawMessage{}
 	for i := 0; i < len(originalDocs); i++ {
 		original := originalDocs[i]
 		modified := modifiedDocs[i]
@@ -256,7 +258,7 @@ func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 			return nil, err
 		}
 
-		result = append(result, json.RawMessage(patch))
+		result = append(result, stdlib.RawMessage(patch))
 	}
 
 	return json.Marshal(result)

--- a/patch.go
+++ b/patch.go
@@ -2,12 +2,13 @@ package jsonpatch
 
 import (
 	"bytes"
-	"encoding/json"
+	stdlib "encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
+	json "github.com/evanphx/json-patch/json"
 )
 
 const (
@@ -35,14 +36,14 @@ var (
 )
 
 type lazyNode struct {
-	raw   *json.RawMessage
+	raw   *stdlib.RawMessage
 	doc   partialDoc
 	ary   partialArray
 	which int
 }
 
 // Operation is a single JSON-Patch step, such as a single 'add' operation.
-type Operation map[string]*json.RawMessage
+type Operation map[string]*stdlib.RawMessage
 
 // Patch is an ordered collection of Operations.
 type Patch []Operation
@@ -57,7 +58,7 @@ type container interface {
 	remove(key string) error
 }
 
-func newLazyNode(raw *json.RawMessage) *lazyNode {
+func newLazyNode(raw *stdlib.RawMessage) *lazyNode {
 	return &lazyNode{raw: raw, doc: nil, ary: nil, which: eRaw}
 }
 
@@ -75,7 +76,7 @@ func (n *lazyNode) MarshalJSON() ([]byte, error) {
 }
 
 func (n *lazyNode) UnmarshalJSON(data []byte) error {
-	dest := make(json.RawMessage, len(data))
+	dest := make(stdlib.RawMessage, len(data))
 	copy(dest, data)
 	n.raw = &dest
 	n.which = eRaw
@@ -91,7 +92,7 @@ func deepCopy(src *lazyNode) (*lazyNode, int, error) {
 		return nil, 0, err
 	}
 	sz := len(a)
-	ra := make(json.RawMessage, sz)
+	ra := make(stdlib.RawMessage, sz)
 	copy(ra, a)
 	return newLazyNode(&ra), sz, nil
 }
@@ -680,11 +681,11 @@ func (p Patch) copy(doc *container, op Operation, accumulatedCopySize *int64) er
 
 // Equal indicates if 2 JSON documents have the same structural equality.
 func Equal(a, b []byte) bool {
-	ra := make(json.RawMessage, len(a))
+	ra := make(stdlib.RawMessage, len(a))
 	copy(ra, a)
 	la := newLazyNode(&ra)
 
-	rb := make(json.RawMessage, len(b))
+	rb := make(stdlib.RawMessage, len(b))
 	copy(rb, b)
 	lb := newLazyNode(&rb)
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -2,10 +2,11 @@ package jsonpatch
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
+
+	json "github.com/evanphx/json-patch/json"
 )
 
 func reformatJSON(j string) string {


### PR DESCRIPTION
Addresses #82 

Adds new API method `jsonpatch.SetAPI(otherJsonLibrary)` which allows for a custom JSON library to be used, as long as it implements 3 required methods: `Marshal()`, `MarshalIndent()`, `Unmarshal()`. This JSON library's methods will then be used in place of standard library methods. To restore to using standard library, use `jsonpatch.ResetAPI()`