### PR TITLE
Conform to RFC6902 replacement semantics

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -384,13 +384,17 @@ func (d *partialDoc) add(key string, val *lazyNode) error {
 }
 
 func (d *partialDoc) get(key string) (*lazyNode, error) {
-	return (*d)[key], nil
+	v, ok := (*d)[key]
+	if !ok {
+		return v, errors.Wrapf(ErrMissing, "unable to get nonexistent key: %s", key)
+	}
+	return v, nil
 }
 
 func (d *partialDoc) remove(key string) error {
 	_, ok := (*d)[key]
 	if !ok {
-		return errors.Wrapf(ErrMissing, "Unable to remove nonexistent key: %s", key)
+		return errors.Wrapf(ErrMissing, "unable to remove nonexistent key: %s", key)
 	}
 
 	delete(*d, key)
@@ -612,7 +616,7 @@ func (p Patch) test(doc *container, op Operation) error {
 	}
 
 	val, err := con.get(key)
-	if err != nil {
+	if err != nil && errors.Cause(err) != ErrMissing {
 		return errors.Wrapf(err, "error in test for path: '%s'", path)
 	}
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -332,6 +332,10 @@ var BadCases = []BadCase{
 		`{ "foo": [ "all", "grass", "cows", "eat" ] }`,
 		`[ { "op": "move", "from": "/foo/1", "path": "/foo/4" } ]`,
 	},
+	{
+		`{ "baz": "qux" }`,
+		`[ { "op": "replace", "path": "/foo", "value": "bar" } ]`,
+	},
 }
 
 // This is not thread safe, so we cannot run patch tests in parallel.

--- a/patch_test.go
+++ b/patch_test.go
@@ -187,6 +187,11 @@ var Cases = []Case{
 		`{ "foo": [["bar"], "bar"]}`,
 	},
 	{
+		`{ "foo": null}`,
+		`[{"op": "copy", "path": "/bar", "from": "/foo"}]`,
+		`{ "foo": null, "bar": null}`,
+	},
+	{
 		`{ "foo": ["bar","qux","baz"]}`,
 		`[ { "op": "remove", "path": "/foo/-2"}]`,
 		`{ "foo": ["bar", "baz"]}`,

--- a/patch_test.go
+++ b/patch_test.go
@@ -468,6 +468,18 @@ var TestCases = []TestCase{
 		false,
 		"/foo",
 	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "test", "path": "/baz", "value": "bar" } ]`,
+		false,
+		"/baz",
+	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "test", "path": "/baz", "value": null } ]`,
+		true,
+		"/baz",
+	},
 }
 
 func TestAllTest(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -336,6 +336,11 @@ var BadCases = []BadCase{
 		`{ "baz": "qux" }`,
 		`[ { "op": "replace", "path": "/foo", "value": "bar" } ]`,
 	},
+	// Can't copy from non-existent "from" key.
+	{
+		`{ "foo": "bar"}`,
+		`[{"op": "copy", "path": "/qux", "from": "/baz"}]`,
+	},
 }
 
 // This is not thread safe, so we cannot run patch tests in parallel.


### PR DESCRIPTION
A "replace" patch operation referencing a key that does not exist in the target object are currently being accepted; ultimately becoming an "add" operation on the target object. This is incorrect per the specification:

From https://tools.ietf.org/html/rfc6902#section-4.3 section about
"replace":

    The target location MUST exist for the operation to be successful.

This corrects the behavior by returning an error in this situation.

📎 https://github.com/evanphx/json-patch/issues/78