### PR TITLE
Fix panic when SupportNegativeIndices is false

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -429,14 +429,14 @@ func (d *partialArray) add(key string, val *lazyNode) error {
 		return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
 	}
 
-	if SupportNegativeIndices {
+	if idx < 0 {
+		if !SupportNegativeIndices {
+			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
 		if idx < -len(ary) {
 			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
 		}
-
-		if idx < 0 {
-			idx += len(ary)
-		}
+		idx += len(ary)
 	}
 
 	copy(ary[0:idx], cur[0:idx])
@@ -473,14 +473,14 @@ func (d *partialArray) remove(key string) error {
 		return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
 	}
 
-	if SupportNegativeIndices {
+	if idx < 0 {
+		if !SupportNegativeIndices {
+			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
 		if idx < -len(cur) {
 			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
 		}
-
-		if idx < 0 {
-			idx += len(cur)
-		}
+		idx += len(cur)
 	}
 
 	ary := make([]*lazyNode, len(cur)-1)

--- a/patch_test.go
+++ b/patch_test.go
@@ -477,3 +477,65 @@ func TestAllTest(t *testing.T) {
 		}
 	}
 }
+
+func TestAdd(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		key                    string
+		val                    lazyNode
+		arr                    partialArray
+		rejectNegativeIndicies bool
+		err                    string
+	}{
+		{
+			name: "should work",
+			key:  "0",
+			val:  lazyNode{},
+			arr:  partialArray{},
+		},
+		{
+			name: "index too large",
+			key:  "1",
+			val:  lazyNode{},
+			arr:  partialArray{},
+			err:  "Unable to access invalid index: 1: invalid index referenced",
+		},
+		{
+			name: "negative should work",
+			key:  "-1",
+			val:  lazyNode{},
+			arr:  partialArray{},
+		},
+		{
+			name: "negative too small",
+			key:  "-2",
+			val:  lazyNode{},
+			arr:  partialArray{},
+			err:  "Unable to access invalid index: -2: invalid index referenced",
+		},
+		{
+			name:                   "negative but negative disabled",
+			key:                    "-1",
+			val:                    lazyNode{},
+			arr:                    partialArray{},
+			rejectNegativeIndicies: true,
+			err:                    "Unable to access invalid index: -1: invalid index referenced",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			SupportNegativeIndices = !tc.rejectNegativeIndicies
+			key := tc.key
+			arr := &tc.arr
+			val := &tc.val
+			err := arr.add(key, val)
+			if err == nil && tc.err != "" {
+				t.Errorf("Expected error but got none! %v", tc.err)
+			} else if err != nil && tc.err == "" {
+				t.Errorf("Did not expect error but go: %v", err)
+			} else if err != nil && err.Error() != tc.err {
+				t.Errorf("Expected error %v but got error %v", tc.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If SupportNegativeIndices is false then a negative indicie will cause a panic.
This regression was introduced in: fcd53eccb4f88d7e54b742358017d72c9b34ae44
Before that change we always checked the validity of the negative index.