### PR TITLE
Allow case sensitive matching for PATCH keywords

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -249,7 +249,7 @@ func (o Operation) Kind() string {
 			return "unknown"
 		}
 
-		return op
+		return strings.ToLower(op)
 	}
 
 	return "unknown"


### PR DESCRIPTION
Change the requested `op` to always be in lower case. Some clients might send `op` request with capitalized strings, which would break the `ApplyIndent` `switch` by returning an `Unexpected kind` (example `Unexpected Kind: Replace`)