### PR TITLE
Update LICENCE to fix minor typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ modification, are permitted provided that the following conditions are met:
 
 * Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice
+* Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 * Neither the name of the Evan Phoenix nor the names of its contributors 


### PR DESCRIPTION
Add a missing comma according to the official BSD-3-Clause templates.

Resource: https://opensource.org/licenses/BSD-3-Clause

This is important in order to be compatible with the official template to avoid having LICENCE detectors failing to match the LICENCE like in https://github.com/elastic/beats/pull/18817#discussion_r432321740

cc: @evanphx