### PR TITLE
Revert "Conform to RFC6902 replacement semantics" for v4.x

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -392,17 +392,13 @@ func (d *partialDoc) add(key string, val *lazyNode) error {
 }
 
 func (d *partialDoc) get(key string) (*lazyNode, error) {
-	v, ok := (*d)[key]
-	if !ok {
-		return v, errors.Wrapf(ErrMissing, "unable to get nonexistent key: %s", key)
-	}
-	return v, nil
+	return (*d)[key], nil
 }
 
 func (d *partialDoc) remove(key string) error {
 	_, ok := (*d)[key]
 	if !ok {
-		return errors.Wrapf(ErrMissing, "unable to remove nonexistent key: %s", key)
+		return errors.Wrapf(ErrMissing, "Unable to remove nonexistent key: %s", key)
 	}
 
 	delete(*d, key)
@@ -624,7 +620,7 @@ func (p Patch) test(doc *container, op Operation) error {
 	}
 
 	val, err := con.get(key)
-	if err != nil && errors.Cause(err) != ErrMissing {
+	if err != nil {
 		return errors.Wrapf(err, "error in test for path: '%s'", path)
 	}
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -336,11 +336,6 @@ var BadCases = []BadCase{
 		`{ "baz": "qux" }`,
 		`[ { "op": "replace", "path": "/foo", "value": "bar" } ]`,
 	},
-	// Can't copy from non-existent "from" key.
-	{
-		`{ "foo": "bar"}`,
-		`[{"op": "copy", "path": "/qux", "from": "/baz"}]`,
-	},
 }
 
 // This is not thread safe, so we cannot run patch tests in parallel.

--- a/patch_test.go
+++ b/patch_test.go
@@ -332,10 +332,6 @@ var BadCases = []BadCase{
 		`{ "foo": [ "all", "grass", "cows", "eat" ] }`,
 		`[ { "op": "move", "from": "/foo/1", "path": "/foo/4" } ]`,
 	},
-	{
-		`{ "baz": "qux" }`,
-		`[ { "op": "replace", "path": "/foo", "value": "bar" } ]`,
-	},
 }
 
 // This is not thread safe, so we cannot run patch tests in parallel.

--- a/patch_test.go
+++ b/patch_test.go
@@ -468,18 +468,6 @@ var TestCases = []TestCase{
 		false,
 		"/foo",
 	},
-	{
-		`{ "foo": "bar" }`,
-		`[ { "op": "test", "path": "/baz", "value": "bar" } ]`,
-		false,
-		"/baz",
-	},
-	{
-		`{ "foo": "bar" }`,
-		`[ { "op": "test", "path": "/baz", "value": null } ]`,
-		true,
-		"/baz",
-	},
 }
 
 func TestAllTest(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -187,11 +187,6 @@ var Cases = []Case{
 		`{ "foo": [["bar"], "bar"]}`,
 	},
 	{
-		`{ "foo": null}`,
-		`[{"op": "copy", "path": "/bar", "from": "/foo"}]`,
-		`{ "foo": null, "bar": null}`,
-	},
-	{
 		`{ "foo": ["bar","qux","baz"]}`,
 		`[ { "op": "remove", "path": "/foo/-2"}]`,
 		`{ "foo": ["bar", "baz"]}`,


### PR DESCRIPTION
Related to https://github.com/containerd/cri/pull/1551#discussion_r465789692

Pull request https://github.com/evanphx/json-patch/pull/85 introduced a potentially breaking change, and (see the discussion on https://github.com/kubernetes/kubernetes/pull/91622#issuecomment-642781591) resulted in Kubernetes to hold-back this change in their dependencies. Given that this change can be considered a breaking change, it should probably have warranted a major version bump (to stick with SemVer).

Now that this project has a v5.x release, it should be possible to revert the change for v4.x. Consumers of this package that want to opt-on to the breaking change can update their dependency to use the v5 module, and consumers that are not (yet) ready to opt-in can continue using the v4.x releases until they are.

If this pull request is accepted, I would like to request a v4.8.0 patch release to be tagged with this change, to allow kubernetes to use a tagged version in its dependencies, and to prevent (other) consumers from "accidentally" opting in.

Thanks in advance for considering!

@evanphx PTAL


/cc @liggitt @dims (who are more familiar with the changes, and could possibly provide more input if needed 🤗)


