### PR TITLE
WIP: Allow "" as a valid Path, with some limitations

### DIFF
--- a/patch_test.go
+++ b/patch_test.go
@@ -222,6 +222,11 @@ var Cases = []Case{
 		`{ "bar": [null]}`,
 	},
 	{
+		`{ "bar": "baz" }`,
+		`[ { "op": "replace", "path": "", "value": { "foo": "bar" } } ]`,
+		`{ "foo": "bar" }`,
+	},
+	{
 		fmt.Sprintf(`{ "foo": ["A", %q] }`, repeatedA(48)),
 		// The wrapping quotes around 'A's are included in the copy
 		// size, so each copy operation increases the size by 50 bytes.


### PR DESCRIPTION
## EDIT: Don't merge!
This might have some unintended side-effects.  Still looking at the exact details and pretty busy, but feel free to bump this.

---

See https://github.com/evanphx/json-patch/issues/86 for further details and issues which may not be addressed by this.

Note that this is not a complete implementation but covers some common cases.  A (slightly?) deeper refactor is required in order to support replacing arrays with objects, or vice versa, and more tests are needed, but perhaps this can be a starting point.

RFC6902 specifies that the "path" member of an operation is a
JSON Pointer (RFC6901), but RFC6901 clearly specifies that an empty
path refers to the root document.

https://tools.ietf.org/html/rfc6902#section-4

https://tools.ietf.org/html/rfc6901#section-5

This commit special-cases partial objects and arrays for some possible
empty path cases.

- findObject now returns the given container if path is "".
- partialDoc set, get, and remove now support empty path.
- partialArray set, get, and remove now support empty path.
- set currently only supports setting to the same type of object.

Other methods of the container interface return an error if an empty
path is given.

Tests currently only cover the valid "replace" case for partialDoc.