### PR TITLE
Remove 4.x go.mod to make semantic versions addressable by tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,0 @@
-module github.com/evanphx/json-patch
-
-go 1.12
-
-require (
-	github.com/jessevdk/go-flags v1.4.0
-	github.com/pkg/errors v0.8.1
-)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
As noted in https://github.com/evanphx/json-patch/issues/98, the presence of a go.mod file in the root of the module in tagged semantic versions >= v2.x means go module consumers cannot address v4.x releases using semantic versions

For example, the recently tagged v4.8.0 has to be referred to as `v0.0.0-20200808040245-162e5629780b`, directly referencing the git SHA.

https://github.com/evanphx/json-patch/pull/100 resolved this for v5+, but removing the go.mod in the module root would allow v4.x consumers to resume referencing semantic version.

If this was merged and a v4.9.0 release tagged, consumers could do `go get github.com/evanphx/json-patch@v4.9.0` and record the tagged release in their go.mod files correctly.

This is more of a tidyness issue than a functional one (it makes the versions recorded in consumers' go.mod files easier to understand, but doesn't actually change the code that is run), though if consumers have to refer to v4.8.0 as `v0.0.0-20200808040245-162e5629780b`, go module version selection can get confused and prefer `v4.6.0-incompatible` thinking it is newer.