### PR TITLE
Fixes evanphx/json-patch#128 - custom marshalling for doc nodes

### DIFF
--- a/v5/go.sum
+++ b/v5/go.sum
@@ -2,3 +2,7 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/v5/merge.go
+++ b/v5/merge.go
@@ -27,21 +27,33 @@ func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
 }
 
 func mergeDocs(doc, patch *partialDoc, mergeMerge bool) {
-	for k, v := range *patch {
+	for k, v := range patch.obj {
 		if v == nil {
 			if mergeMerge {
-				(*doc)[k] = nil
+				idx := -1
+				for i, item := range doc.items {
+					if item.Key == k {
+						idx = i
+						break
+					}
+				}
+				if idx == -1 {
+					doc.items = append(doc.items, docItem{Key: k, Value: nil})
+				} else {
+					doc.items[idx].Value = nil
+				}
+				doc.obj[k] = nil
 			} else {
-				delete(*doc, k)
+				_ = doc.remove(k, &ApplyOptions{})
 			}
 		} else {
-			cur, ok := (*doc)[k]
+			cur, ok := doc.obj[k]
 
 			if !ok || cur == nil {
 				pruneNulls(v)
-				(*doc)[k] = v
+				_ = doc.set(k, v, &ApplyOptions{})
 			} else {
-				(*doc)[k] = merge(cur, v, mergeMerge)
+				_ = doc.set(k, merge(cur, v, mergeMerge), &ApplyOptions{})
 			}
 		}
 	}
@@ -62,9 +74,9 @@ func pruneNulls(n *lazyNode) {
 }
 
 func pruneDocNulls(doc *partialDoc) *partialDoc {
-	for k, v := range *doc {
+	for k, v := range doc.obj {
 		if v == nil {
-			delete(*doc, k)
+			_ = doc.remove(k, &ApplyOptions{})
 		} else {
 			pruneNulls(v)
 		}
@@ -113,19 +125,19 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 
 	patchErr := json.Unmarshal(patchData, patch)
 
-	if _, ok := docErr.(*json.SyntaxError); ok {
+	if isSyntaxError(docErr) {
 		return nil, errBadJSONDoc
 	}
 
-	if _, ok := patchErr.(*json.SyntaxError); ok {
+	if isSyntaxError(patchErr) {
 		return nil, errBadJSONPatch
 	}
 
-	if docErr == nil && *doc == nil {
+	if docErr == nil && doc.obj == nil {
 		return nil, errBadJSONDoc
 	}
 
-	if patchErr == nil && *patch == nil {
+	if patchErr == nil && patch.obj == nil {
 		return nil, errBadJSONPatch
 	}
 
@@ -160,6 +172,16 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	}
 
 	return json.Marshal(doc)
+}
+
+func isSyntaxError(err error) bool {
+	if _, ok := err.(*json.SyntaxError); ok {
+		return true
+	}
+	if _, ok := err.(*syntaxError); ok {
+		return true
+	}
+	return false
 }
 
 // resemblesJSONArray indicates whether the byte-slice "appears" to be

--- a/v5/merge_test.go
+++ b/v5/merge_test.go
@@ -62,7 +62,7 @@ func TestMergePatchRecursesIntoObjects(t *testing.T) {
 	exp := `{ "person": { "title": "goodbye", "age": 18 } }`
 
 	if !compareJSON(exp, res) {
-		t.Fatalf("Key was not replaced")
+		t.Fatalf("Key was not replaced: %s", res)
 	}
 }
 


### PR DESCRIPTION
Rather than using a `map[string]*lazyNode` for the doc (object) nodes, this is changed to use a rich type with both a map and an array of key-value pairs, and custom `MarshalJSON` and `UnmarshalJSON` functions.