### PR TITLE
Fix partial negative indice support in v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# editor and IDE paraphernalia
+.idea
+.vscode
+
+# macOS paraphernalia
+.DS_Store

--- a/patch.go
+++ b/patch.go
@@ -412,6 +412,17 @@ func (d *partialArray) set(key string, val *lazyNode) error {
 	if err != nil {
 		return err
 	}
+
+	if idx < 0 {
+		if !SupportNegativeIndices {
+			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		if idx < -len(*d) {
+			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		idx += len(*d)
+	}
+
 	(*d)[idx] = val
 	return nil
 }
@@ -460,6 +471,16 @@ func (d *partialArray) get(key string) (*lazyNode, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	if idx < 0 {
+		if !SupportNegativeIndices {
+			return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		if idx < -len(*d) {
+			return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		}
+		idx += len(*d)
 	}
 
 	if idx >= len(*d) {


### PR DESCRIPTION
Currently the negative indice support in v4 is "partial" (only implemented for add/remove op to JSON array) so that a get/set op with negative indice will result in panic.

This PR fixed this issue and also added a general gitignore for the project.