### PR TITLE
Support custom separator

### DIFF
--- a/v5/patch.go
+++ b/v5/patch.go
@@ -751,7 +751,7 @@ func ensurePathExists(pd *container, path string, options *ApplyOptions) error {
 	var err error
 	var arrIndex int
 
-	split := strings.Split(path, "/")
+	split := strings.Split(path, options.Separator)
 
 	if len(split) < 2 {
 		return nil

--- a/v5/patch.go
+++ b/v5/patch.go
@@ -442,7 +442,7 @@ func (o Operation) Separator() string {
 		}
 	}
 
-	return SeparatorLeftDash
+	return ""
 }
 
 // From reads the "from" field of the Operation.
@@ -1066,8 +1066,10 @@ func (p Patch) ApplyIndentWithOptions(doc []byte, indent string, options *ApplyO
 	var accumulatedCopySize int64
 
 	for _, op := range p {
-		sep := op.Separator()
-		options.Separator = sep
+		if sep := op.Separator(); sep != "" {
+			options.Separator = sep
+		}
+
 		switch op.Kind() {
 		case "add":
 			err = p.add(&pd, op, options)


### PR DESCRIPTION
`json-patch` cannot be used when the defined JSON document contains a key with `/`.
Consider adding an `sep` in operation as a custom separator?