### PR TITLE
Fix invalid sprintf

### DIFF
--- a/v5/patch.go
+++ b/v5/patch.go
@@ -180,7 +180,7 @@ func (n *partialDoc) UnmarshalJSON(data []byte) error {
 	if t, err := d.Token(); err != nil {
 		return err
 	} else if t != startObject {
-		return &syntaxError{fmt.Sprintf("unexpected JSON token in document node: %s", t)}
+		return &syntaxError{fmt.Sprintf("unexpected JSON token in document node: %v", t)}
 	}
 	for d.More() {
 		k, err := d.Token()


### PR DESCRIPTION
We are using `%s` but the input is not a string. This can result in bad error messages, for example https://go.dev/play/p/NoimdDgOdDR