### PR TITLE
v5/merge: Add CreateAnyMergePatch helper

### DIFF
--- a/v5/merge.go
+++ b/v5/merge.go
@@ -221,6 +221,24 @@ func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 	return nil, errBadMergeTypes
 }
 
+// CreateAnyMergePatch will return a merge patch document capable of converting
+// the original document(s) to the modified document(s).
+// It marshals the input objects to JSON, and then calsl CreateMergePatch.
+// The merge patch returned follows the specification defined at http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
+func CreateAnyMergePatch(original, modified interface{}) ([]byte, error) {
+	originalJSON, err := json.Marshal(original)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal original object: %w", err)
+	}
+
+	modifiedJSON, err := json.Marshal(modified)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified object: %w", err)
+	}
+
+	return CreateMergePatch(originalJSON, modifiedJSON)
+}
+
 // createObjectMergePatch will return a merge-patch document capable of
 // converting the original document to the modified document.
 func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {

--- a/v5/merge_test.go
+++ b/v5/merge_test.go
@@ -643,6 +643,23 @@ func TestCreateMergePatchReplaceKeyNotEscape(t *testing.T) {
 	}
 }
 
+func TestCreateAnyMergePatch(t *testing.T) {
+	original := map[string]interface{}{"title": "hello", "nested": map[string]int{"one": 1, "two": 2}}
+	modified := map[string]interface{}{"title": "goodbye", "nested": map[string]int{"one": 2, "two": 2}}
+
+	exp := `{ "title": "goodbye", "nested": {"one": 2}  }`
+
+	res, err := CreateAnyMergePatch(original, modified)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Key was not replaced")
+	}
+}
+
 func TestMergePatchReplaceKeyNotEscaping(t *testing.T) {
 	doc := `{ "obj": { "title/escaped": "hello" } }`
 	pat := `{ "obj": { "title/escaped": "goodbye" } }`


### PR DESCRIPTION
Syntactic sugar, so folks don't have to marshal locally before calling `CreateMergePatch`.  This condenses three calls (marshal original, marshal modified, `CreateMergePatch`) into a single `CreateAnyMergePatch` for callers starting with unserialized objects.
