### PR TITLE
Compare strings after decoding them to handle unicode correctly. Fixes #172

### DIFF
--- a/v5/patch.go
+++ b/v5/patch.go
@@ -334,7 +334,27 @@ func (n *lazyNode) equal(o *lazyNode) bool {
 				return false
 			}
 
-			return bytes.Equal(n.compact(), o.compact())
+			nc := n.compact()
+			oc := o.compact()
+
+			if nc[0] == '"' && oc[0] == '"' {
+				// ok, 2 strings
+
+				var ns, os string
+
+				err := json.Unmarshal(nc, &ns)
+				if err != nil {
+					return false
+				}
+				err = json.Unmarshal(oc, &os)
+				if err != nil {
+					return false
+				}
+
+				return ns == os
+			}
+
+			return bytes.Equal(nc, oc)
 		}
 	}
 

--- a/v5/patch_test.go
+++ b/v5/patch_test.go
@@ -1078,6 +1078,12 @@ var EqualityCases = []EqualityCase{
 		`null`,
 		false,
 	},
+	{
+		"Unicode",
+		`{"name": "λJohn"}`,
+		`{"name": "\u03BBJohn"}`,
+		true,
+	},
 }
 
 func TestEquality(t *testing.T) {


### PR DESCRIPTION
Closes #172 