### PR TITLE
Drop the reference to gopkg.in for v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ well as for calculating & applying [RFC7396 JSON merge patches](https://tools.ie
 go get -u github.com/evanphx/json-patch/v5
 ```
 
-**Stable Versions**:
-* Version 5: `go get -u gopkg.in/evanphx/json-patch.v5`
-* Version 4: `go get -u gopkg.in/evanphx/json-patch.v4`
+If you need version 4, use `go get -u gopkg.in/evanphx/json-patch.v4`
 
 (previous versions below `v3` are unavailable)
 


### PR DESCRIPTION
This aligns with the module declaration in go.mod.