### PR TITLE
Add a MergePatchWithOptions method

### DIFF
--- a/v5/merge.go
+++ b/v5/merge.go
@@ -111,15 +111,18 @@ var errBadMergeTypes = fmt.Errorf("Mismatched JSON Documents")
 // applying this resulting merged merge patch to a document yields the same
 // as merging each merge patch to the document in succession.
 func MergeMergePatches(patch1Data, patch2Data []byte) ([]byte, error) {
-	return doMergePatch(patch1Data, patch2Data, true)
+	return doMergePatch(patch1Data, patch2Data, true, NewApplyOptions())
 }
 
 // MergePatch merges the patchData into the docData.
 func MergePatch(docData, patchData []byte) ([]byte, error) {
-	return doMergePatch(docData, patchData, false)
+	return doMergePatch(docData, patchData, false, NewApplyOptions())
+}
+func MergePatchWithOptions(docData, patchData []byte, options *ApplyOptions) ([]byte, error) {
+	return doMergePatch(docData, patchData, false, options)
 }
 
-func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
+func doMergePatch(docData, patchData []byte, mergeMerge bool, options *ApplyOptions) ([]byte, error) {
 	if !json.Valid(docData) {
 		return nil, ErrBadJSONDoc
 	}
@@ -127,8 +130,6 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	if !json.Valid(patchData) {
 		return nil, ErrBadJSONPatch
 	}
-
-	options := NewApplyOptions()
 
 	doc := &partialDoc{
 		opts: options,

--- a/v5/merge_test.go
+++ b/v5/merge_test.go
@@ -1,6 +1,8 @@
 package jsonpatch
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -693,5 +695,31 @@ func TestMergeMergePatches(t *testing.T) {
 			t.Logf("Expected %v", c.exp)
 			t.Fatalf("Merged merge patch is incorrect")
 		}
+	}
+}
+
+func TestMergePatchWithOptions(t *testing.T) {
+	b := &bytes.Buffer{}
+	enc := json.NewEncoder(b)
+	enc.SetEscapeHTML(false)
+
+	v := struct {
+		X string
+	}{X: "&<>"}
+
+	if err := enc.Encode(&v); err != nil {
+		t.Fatal(err)
+	}
+	target := []byte(`{"key1": "val1", "key2": "val2"}`)
+
+	opts := NewApplyOptions()
+	opts.EscapeHTML = false
+
+	modified, err := MergePatchWithOptions(b.Bytes(), target, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compareJSON(string(modified), `{"X":"&<>","key1":"val1","key2":"val2"}`) {
+		t.Fatalf("testMergePatchWithOptions fails for %s", string(modified))
 	}
 }


### PR DESCRIPTION
By default The `MergePatch` method  escapes html chars. An additional method can take more options